### PR TITLE
Modified the header location for CSQLiteMac module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # CSQLite
 
 C module map for SQLite
+
+## How to build for OS X
+
+The official `sqlite3.h` in the system is inside `/usr/include/sqlite3.h` after the install of Xcode's command line developer tools, but this header [has a bug](https://bugs.swift.org/browse/SR-89). The workaround is install SQLite from Homebrew:
+
+`$ brew install sqlite3`

--- a/module.modulemap
+++ b/module.modulemap
@@ -5,7 +5,7 @@ module CSQLiteLinux [system] {
 }
 
 module CSQLiteMac [system] {
-    header "/opt/local/include/sqlite3.h"
+    header "/usr/local/opt/sqlite/include/sqlite3.h"
     link "sqlite3"
     export *
 }


### PR DESCRIPTION
I've modified the header location to use `sqlite3.h` from Homebrew installation. The default OS X header has an error when building and it's better to use Homebrew because it has become the most used package manager.
